### PR TITLE
Added override to CircularMenu to accept a static icon

### DIFF
--- a/lib/src/circular_menu.dart
+++ b/lib/src/circular_menu.dart
@@ -38,6 +38,7 @@ class CircularMenu extends StatefulWidget {
   final double toggleButtonMargin;
   final Color toggleButtonIconColor;
   final AnimatedIconData toggleButtonAnimatedIconData;
+  final IconData toggleButtonIconData;
 
   /// staring angle in clockwise radian
   final double startingAngleInRadian;
@@ -65,6 +66,7 @@ class CircularMenu extends StatefulWidget {
     this.toggleButtonSize = 40,
     this.toggleButtonIconColor,
     this.toggleButtonAnimatedIconData = AnimatedIcons.menu_close,
+    this.toggleButtonIconData,
     this.key,
     this.startingAngleInRadian,
     this.endingAngleInRadian,
@@ -216,7 +218,8 @@ class CircularMenuState extends State<CircularMenu>
       child: Align(
         alignment: widget.alignment,
         child: CircularMenuItem(
-          icon: null,
+          icon: widget.toggleButtonIconData,
+          iconSize: widget.toggleButtonSize,
           margin: widget.toggleButtonMargin,
           color: widget.toggleButtonColor ?? Theme.of(context).primaryColor,
           padding: (-_animation.value * widget.toggleButtonPadding * 0.5) +
@@ -230,13 +233,15 @@ class CircularMenuState extends State<CircularMenu>
             }
           },
           boxShadow: widget.toggleButtonBoxShadow,
-          animatedIcon: AnimatedIcon(
-            icon:
-                widget.toggleButtonAnimatedIconData, //AnimatedIcons.menu_close,
-            size: widget.toggleButtonSize,
-            color: widget.toggleButtonIconColor ?? Colors.white,
-            progress: _animation,
-          ),
+          animatedIcon: widget.toggleButtonIconData == null ?
+            AnimatedIcon(
+              icon:
+              widget.toggleButtonAnimatedIconData, //AnimatedIcons.menu_close,
+              size: widget.toggleButtonSize,
+              color: widget.toggleButtonIconColor ?? Colors.white,
+              progress: _animation,
+            )
+            : null,
         ),
       ),
     );


### PR DESCRIPTION
None of the animated icons make sense for my use case (social share).  I would prefer to use the static share icon in this case.

Changes submitted will work unchanged for anyone already using the library, this just provides the option to override with a static icon if provided